### PR TITLE
Fix middleware matcher for exam routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -153,6 +153,6 @@ export const config = {
   matcher: [
     '/panel/:path*',  // Yönetici paneli
     '/login',         // Login sayfası
-    '/exam/:path*',   // Sınav sayfaları
+    '/sinav/:path*',  // Sınav sayfaları
   ],
 }


### PR DESCRIPTION
## Summary
- correct path matcher to protect `/sinav` exam pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68481d042b448325966487794f5698aa